### PR TITLE
Support getting target_id from an unauthorized request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ node_modules
 /.settings/
 /.project
 
+.idea/

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var jwt = require('jsonwebtoken');
 var request = require('request');
 
@@ -133,8 +134,12 @@ module.exports = (function() {
 
       // Validate whether we have enough information to authenticate
       if (!(delegate_config && delegate_config.refresh_token && delegate_config.target_id)) {
+        if (res) return callback(new Error('Not enough information for a delegation call'));
         logger("No v1 auth possible.  Attempting an unauthenticated request");
-        return request(options, callback);
+        return request(_.omit(options, ['auth']), function(err, res, body) {
+          if (res.statusCode === 401) v1auth(res);
+          else callback(err, res, body);
+        });
       }
 
       retrieve_delegated_token(delegate_config, function(err, tok) {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "auth0": "^2.3.1",
     "jsonwebtoken": "^7.1.9",
+    "lodash": "^4.17.4",
     "node-cache": "^3.2.1",
     "request": "^2.74.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,7 @@ You can run tests via `grunt` or `grunt test`, but keep in mind that the tests a
 | CIMPRESS_IO_REFRESH_TOKEN | A refresh token retrieved from developer.cimpress.io. |
 | CIMPRESS_IO_CLIENT_ID | The client id you wish to use to request client credential grants (https://auth0.com/docs/api-auth/grant/client-credentials). |
 | CIMPRESS_IO_CLIENT_SECRET | The client secret you wish to use to request client credential grants (https://auth0.com/docs/api-auth/grant/client-credentials). |
+| CIMPRESS_IO_TARGET_ID | The target ID used for delegation flows |
 | API_THAT_SUPPORTS_CLIENT_GRANTS | The URL for any `GET` endpoint on an API that supports client credential grants (https://auth0.com/docs/api-auth/grant/client-credentials). |
 | API_THAT_SUPPORTS_DELEGATION | The URL for any `GET` endpoint on an API that supports delegated tokens (https://auth0.com/docs/api-auth/grant/client-credentials). |
 

--- a/test/delegation.test.js
+++ b/test/delegation.test.js
@@ -14,7 +14,7 @@ describe('Auth0 v1 delegation', function () {
   });
 
   var config = {
-    target_id: "ixwhEFzC5TcFViYmi5xzVevRtx2mSjyG",
+    target_id: process.env.CIMPRESS_IO_TARGET_ID,
     refresh_token: process.env.CIMPRESS_IO_REFRESH_TOKEN
   };
 

--- a/test/delegation.test.js
+++ b/test/delegation.test.js
@@ -29,4 +29,15 @@ describe('Auth0 v1 delegation', function () {
       done();
     });
   });
+
+  it('should make a successful request against a backing API without a provided target_id', function (done) {
+    request({
+      auth: { refresh_token: config.refresh_token },
+      url: process.env.API_THAT_SUPPORTS_DELEGATION
+    }, function(err, res, body) {
+      expect(err).to.be.null;
+      expect(res.statusCode).not.to.equal(401);
+      done();
+    })
+  });
 });


### PR DESCRIPTION
The client didn't support getting target_id from making an unauthorized request, even though there's code to parse the header; it would simply give up. With this commit it should and should fallback to old behavior otherwise